### PR TITLE
issue #2: implements custom profile fields support

### DIFF
--- a/local/autogroup/classes/sort_module/user_info_field.php
+++ b/local/autogroup/classes/sort_module/user_info_field.php
@@ -1,0 +1,130 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * autogroup local plugin
+ *
+ * A course object relates to a Moodle course and acts as a container
+ * for multiple groups. Initialising a course object will automatically
+ * load each autogroup group for that course into memory.
+ *
+ * @package    local
+ * @subpackage autogroup
+ * @author     Arnaud Trouvé (arnaud.trouve@andil.fr)
+ * @date       2017
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace local_autogroup\sort_module;
+
+use local_autogroup\sort_module;
+use local_autogroup\exception;
+use \stdClass;
+
+/**
+ * Class course
+ * @package local_autogroup\domain
+ */
+class user_info_field extends sort_module
+{
+    /**
+     * @param stdClass $config
+     * @param int $courseid
+     */
+    public function __construct($config, $courseid)
+    {
+        if($this->config_is_valid($config)){
+            $this->field = $config->field;
+        }
+        $this->courseid = (int) $courseid;
+    }
+
+    /**
+     * @param stdClass $config
+     * @return bool
+     */
+    public function config_is_valid(stdClass $config)
+    {
+        if(!isset($config->field)){
+            return false;
+        }
+
+        //ensure that the stored option is valid
+        if(array_key_exists($config->field, $this->get_config_options())){
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param stdClass $user
+     * @return array $result
+     */
+    public function eligible_groups_for_user(stdClass $user)
+    {
+        global $DB;
+
+        $field = $this->field;
+        $data = $DB->get_record('user_info_data', ['fieldid' => $field, 'userid' => $user->id]);
+        if ($data && !empty($data->data)){
+            return [$data->data];
+        }
+        else {
+            return [];
+        }
+    }
+
+    /**
+     * Returns the options to be displayed on the autgroup_set
+     * editing form. These are defined per-module.
+     *
+     * @return array
+     */
+    public function get_config_options(){
+        global $DB;
+
+        $options = [];
+        $infofields = $DB->get_records('user_info_field');
+
+        foreach ($infofields as $field) {
+            $options[$field->id] = $field->name;
+        }
+        return $options;
+    }
+
+    /**
+     * @return bool|string
+     */
+    public function grouping_by(){
+        global $DB;
+        if(empty ($this->field)){
+            return false;
+        }
+
+        $field = $DB->get_field('user_info_field', 'name', ['id' => $this->field]);
+        if (empty($field)) {
+            return false;
+        }
+        return (string) $field;
+    }
+
+    /**
+     * @var string
+     */
+    private $field = '';
+
+}

--- a/local/autogroup/settings.php
+++ b/local/autogroup/settings.php
@@ -84,13 +84,15 @@ if ($hassiteconfig) {
             ''
         )
     );
-    //TODO: This will eventually need reworking to allow for properly dynamic sort modules
-    $choices = array(
-        'auth' => get_string('auth', 'local_autogroup'),
-        'department' => get_string('department', 'local_autogroup'),
-        'institution' => get_string('institution', 'local_autogroup'),
-        'lang' => get_string('lang', 'local_autogroup')
-    );
+    //TODO: group by sort module using optgroup when MDL-61248 is fixed. 
+    $choices = [];
+    $modules = \local_autogroup\get_sort_module_list();
+
+    foreach ($modules as $sortedmodulename => $name) {
+        $sortedmodulename = "\\local_autogroup\\sort_module\\$sortedmodulename";
+        $module = new $sortedmodulename(new stdClass(), 1);
+        $choices = array_merge($choices, $module->get_config_options());
+    }
     $settings->add(
         new admin_setting_configselect(
             'local_autogroup/filter',


### PR DESCRIPTION
In Moodle "**Custom profile field**" appear as "**User profile field**" in menu but in this plugin the class for "standard profile field" is called "**Profile field**". 
So to prevent confusion I called "**Custom profile field**" support "**User info field**" as the related table `mdl_user_info_field`.