### PR TITLE
move changelogs to dedicated file

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,28 @@
+## v2.4
+  * Fixed unnecessary processing on profile update. Thanks to Luuk Verhoeven for this addition.
+
+## v2.3
+  * Added support for custom profile fields.  Thanks to Arnaud Trouvé for this addition.
+
+## v2.2
+  * Performance enhancement: Event listeners now check to see whether triggered by AutoGroup
+
+## v2.1
+  * Switched to individual toggles for event listeners
+  * Minor change to settings structure for improved usability
+  * Fixed compatibility with Moodle 3.1 and onwards
+
+## v2.0
+  * Added support for defining multiple grouping sets on one course
+  * Sort modules are now fully modular
+  * Added new sort module for Totara positional assignments
+
+## v1.1
+  * Fixed a bug which would have resulted in roles being removed from all groupsets across a site
+  * Changed default permissions for plugin files 
+
+## v1.01
+  * Added event handler for course_restored and related setting
+
+## v1.0
+  * Stable release. Tested for compatibility with Moodle 2.7 and 2.8

--- a/README.md
+++ b/README.md
@@ -10,27 +10,6 @@ and so will occur within page loads.
 The system can also monitor manual group setting changes and
 moderate them to ensure that groups are kept neat and tidy.
 
-## Changelog
-* v2.3
-  * Added support for custom profile fields.  Thanks to Arnaud Trouvé for this addition.
-* v2.2
-  * Performance enhancement: Event listeners now check to see whether triggered by AutoGroup
-* v2.1
-  * Switched to individual toggles for event listeners
-  * Minor change to settings structure for improved usability
-  * Fixed compatibility with Moodle 3.1 and onwards
-* v2.0
-  * Added support for defining multiple grouping sets on one course
-  * Sort modules are now fully modular
-  * Added new sort module for Totara positional assignments
-* v1.1
-  * Fixed a bug which would have resulted in roles being removed from all groupsets across a site
-  * Changed default permissions for plugin files 
-* v1.01
-  * Added event handler for course_restored and related setting
-* v1.0
-  * Stable release. Tested for compatibility with Moodle 2.7 and 2.8
-
 ## Install
 
 Install the plugin, like any other plugin.  


### PR DESCRIPTION
Hi Emma,

I noticed that you released the 2.4 version with an updated release note on moodle.org (https://moodle.org/plugins/pluginversion.php?id=17301) but it seems you forgot to update the README.md file on github. :)  
That is what this PR fix but it also move the changelogs to a dedicated CHANGES.md file.
Also I'll suggest you to look at the "release" system on github which can really simplify your release process (https://moodle.org/mod/forum/discuss.php?d=283910) ;)