### PR TITLE
issue #11: added role_deleted event observer

### DIFF
--- a/classes/event_handler.php
+++ b/classes/event_handler.php
@@ -232,6 +232,19 @@ class event_handler
     }
 
     /**
+     * @param event\role_deleted $event
+     * @return mixed
+     */
+    public static function role_deleted(event\role_deleted $event) {
+        global $DB;
+
+        $DB->delete_records('local_autogroup_roles', ['roleid' => $event->objectid]);
+        unset_config('eligiblerole_'.$event->objectid, 'local_autogroup');
+
+        return true;
+    }
+
+    /**
      * @param event\course_created $event
      * @return mixed
      */

--- a/db/events.php
+++ b/db/events.php
@@ -104,6 +104,14 @@ $observers = array(
     ),
 
     array(
+        'eventname' => '\core\event\role_deleted',
+        'callback' => '\local_autogroup\event_handler::role_deleted',
+        'includefile' => 'local/autogroup/classes/event_handler.php',
+        'internal'    => true,
+        'priority'    => 0,
+    ),
+
+    array(
         'eventname' => '\core\event\course_created',
         'callback' => '\local_autogroup\event_handler::course_created',
         'includefile' => 'local/autogroup/classes/event_handler.php',

--- a/version.php
+++ b/version.php
@@ -30,7 +30,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2018070300;
+$plugin->version = 2019010300;
 $plugin->requires = 2013111800.00;       // Requires this Moodle version (2.7).
 $plugin->release = '2.4';                // Plugin release.
 $plugin->component = 'local_autogroup';  // Full name of the plugin (used for diagnostics).


### PR DESCRIPTION
To prevent #11 the event observer remove the deleted role from the groupset and unset it in the global configuration if it has been selected.